### PR TITLE
Modified challenges API

### DIFF
--- a/ideaforce/src/main/java/com/emc/ideaforce/model/ChallengeDetail.java
+++ b/ideaforce/src/main/java/com/emc/ideaforce/model/ChallengeDetail.java
@@ -10,9 +10,9 @@ import javax.persistence.Id;
 import javax.persistence.Table;
 import javax.validation.constraints.NotBlank;
 
+@Data
 @Entity
 @Table(name = "challenges")
-@Data
 @AllArgsConstructor
 @NoArgsConstructor
 public class ChallengeDetail {
@@ -26,5 +26,14 @@ public class ChallengeDetail {
 
     @NotBlank
     private String description;
+
+    @NotBlank
+    private String environmentalIssues;
+
+    @NotBlank
+    private String participationSteps;
+
+    @NotBlank
+    private String reference;
 
 }

--- a/ideaforce/src/main/java/com/emc/ideaforce/service/CommonService.java
+++ b/ideaforce/src/main/java/com/emc/ideaforce/service/CommonService.java
@@ -98,7 +98,7 @@ public class CommonService {
     public void run() {
         for (int i = 1; i <= 10; i++) {
             challengeDetailRepository
-                    .save(new ChallengeDetail(i + "", "CSR Challenge " + i, "About Challenge " + i + "..."));
+                    .save(new ChallengeDetail(i + "", "CSR Challenge " + i, "About Challenge " + i + "...", "environmental issue " + i, "how to participate", "reference"));
         }
 
         storyRepository.deleteAll();

--- a/ideaforce/src/main/resources/templates/challengedetail.html
+++ b/ideaforce/src/main/resources/templates/challengedetail.html
@@ -2,28 +2,43 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:th="http://www.thymeleaf.org">
 <head>
-    <span th:include="common/header :: common-header"></span>
-    <link rel="stylesheet" type="text/css" th:href="@{/assets/css/challengedetail.css}"/>
-    <title>IdeaForce</title>
+  <span th:include="common/header :: common-header"></span>
+  <link rel="stylesheet" type="text/css" th:href="@{/assets/css/challengedetail.css}"/>
+  <title>IdeaForce</title>
 </head>
 <body>
 <header>
-    <div th:replace="common/header :: header('challenges')"></div>
+  <div th:replace="common/header :: header('challenges')"></div>
 </header>
 <div class="container main">
 
-    <div class="card">
-        <h5 class="card-header text-center" th:text="'Challenge #'+ ${challenge.id} + '    ' + ${challenge.name}"></h5>
-        <div class="challenge_banner"></div>
-        <div class="card-body">
-            <h5 class="card-title">About the Challenge</h5>
-            <p class="card-text" th:text="${challenge.description}"></p>
-            <a href="/challenges" class="btn btn-primary">Back to Challenges</a>
-        </div>
+  <div class="card">
+    <h5 class="card-header text-center" th:text="'Challenge #'+ ${challenge.id} + '    ' + ${challenge.name}"></h5>
+    <!-- &#45;&#45; banner image-->
+    <!--<div class="challenge_banner"></div>-->
+    <div>
+      <img  th:src="@{'/assets/images/challenge_image/' + image_ + ${challenge.id}+ '.jpg'}" alt="">
+
     </div>
+    <div class="card-body">
+      <h5 class="card-title">About the Challenge</h5>
+      <p class="card-text" th:utext="${challenge.description}"></p>
+      <hr>
+      <!-- <h5 class="card-title">How you can contribute</h5>-->
+      <p class="card-text" th:utext="${challenge.environmentalIssues}"></p>
+      <hr>
+      <!--<h5 class="card-title">What can be done</h5>-->
+      <p class="card-text" th:utext="${challenge.participationSteps}"></p>
+      <hr>
+      <!-- <h5 class="card-title">Additional resource for reference</h5>-->
+      <p class="card-text" th:utext="${challenge.reference}"></p>
+
+      <a href="/challenges" class="btn btn-primary">Back to Challenges</a>
+    </div>
+  </div>
 </div>
 <footer>
-    <div th:replace="common/header :: footer"></div>
+  <div th:replace="common/header :: footer"></div>
 </footer>
 <span th:include="common/header :: before-body-scripts"></span>
 </body>


### PR DESCRIPTION
## What changed
- Updated challenges API by Neha to consume three additional fields, `environmentalIssues`, `participationSteps`, `reference`.

## Breaking changes
- Since `challenges` schema has changed, make sure to drop the exiting database, either manually or using `spring.jpa.hibernate.ddl-auto=create-drop` in `application.properties`